### PR TITLE
Add main SDK feature flag functionality and test

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -1,0 +1,58 @@
+const axios = require('axios');
+const userInRollout = require('./userIdHash');
+
+const WAYPOST_API_ADDRESS = "http://localhost:5000/";
+
+class Client {
+  constructor(config, context=undefined) {
+    this.config = config;
+    this.context = context;
+    this.featureFlags = {};
+  }
+
+  // Developer must specify a userId key in their argument object
+  addContext(contextObj) {
+    if (!contextObj || !contextObj.userId) {
+      throw new TypeError("Function must take an object containing a userId property");
+    }
+    this.context = contextObj;
+  }
+
+  async startPolling() {
+    while (true) {
+      await this.poll();
+      await this.delay();
+    }
+  }
+
+  async delay() {
+    await new Promise(resolve => setTimeout(resolve, this.config.pollingInterval));
+  }
+
+  async poll() {
+    const res = await axios.get(`${WAYPOST_API_ADDRESS}api/flags?sdk_key=${this.config.sdkKey}`);
+    res.data.forEach(flag => {
+      this.featureFlags[flag.name] = flag;
+    });
+  }
+
+  // defaultVal is a boolean
+  getFeature(featureName, defaultVal) {
+    const featureData = this.featureFlags[featureName];
+
+    if (featureData === undefined) {
+      if (!defaultVal) {
+        throw new TypeError("Must supply a default value argument");
+      }
+      return defaultVal;
+    }
+
+    if (this.context === undefined || featureData.status === false) {
+      return featureData.status;
+    }
+
+    return userInRollout(this.context.userId, featureData['percent_on']);
+  }
+}
+
+module.exports = Client;

--- a/Config.js
+++ b/Config.js
@@ -1,0 +1,18 @@
+const Client = require("./Client");
+
+class Config {
+  constructor(sdkKey, pollingInterval) {
+    this.sdkKey = sdkKey;
+    this.pollingInterval = pollingInterval; // in milliseconds
+    this.client = undefined;
+  }
+
+  connect() {
+    const client = new Client(this);
+    this.client = client;
+    client.startPolling();
+    return this;
+  }
+}
+
+module.exports = Config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "sdk-javascript-client-side",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sdk-javascript-client-side",
+  "version": "1.0.0",
+  "description": "Waypost's SDK for client-side web applications",
+  "main": "Config.js",
+  "scripts": {
+    "start": "node test.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/waypost-io/sdk-javascript-client-side.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/waypost-io/sdk-javascript-client-side/issues"
+  },
+  "homepage": "https://github.com/waypost-io/sdk-javascript-client-side#readme",
+  "dependencies": {
+    "axios": "^0.26.0"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,14 @@
+Config = require('./Config');
+
+const config = new Config('12345', 1000).connect();
+const sdkClient = config.client;
+
+const logStatus = () => {
+  if (sdkClient.getFeature("Test Flag 1")) {
+    console.log("Flag is on");
+  } else {
+    console.log("Flag is off");
+  }
+}
+
+setInterval(logStatus, 1000);

--- a/userIdHash.js
+++ b/userIdHash.js
@@ -14,3 +14,5 @@ function userInRollout(userId, rollout) {
   const hashedUserId = hash(userId);
   return hashedUserId % 100 < rollout;
 }
+
+module.exports = userInRollout;


### PR DESCRIPTION
# MVP of SDK
## Config class
This is the first entrypoint into the SDK. The user/developer just passes in their SDK Key and their desired polling interval into the constructor. The developer should call the `connect()` method to create the client and start the polling. 

## Client class
This is the client which does all the work. It holds the feature flag statuses in its state. These statuses are formatted as a hash keyed by name, so that the developer can easily use the name in their `if/else` statements.   
Other methods on `Client`: 
- `startPolling()` : polling of the Waypost API to get the feature flag data. A delay is placed in between each request with the polling interval specified.
- `addContext()` : the developer can pass in a `userId` and any other parameters they want to keep track of. 
- `getFeature()` : this is what the developer places into his/her codebase as an `if/else` statement to determine what feature flags evaluate to. The method takes in a flag name and a default value (if the status is not found). The method also utilizes the percentage split to determine the status if the flag is used for a rollout or A/B test. NOTE in order for this to work, we need to adjust the API to add this property to the flags data.

# Testing
I also made a `test.js` file which tests the basic functionality. I used a flag I have in my database and toggling it on and off in the UI while observing the `console.log()` statements, so feel free to test it with one of your flags.
This is just a starting point for tests and we'll probably need to add more tests especially for the percentage ones.